### PR TITLE
Fix send() trade

### DIFF
--- a/steam/trade.py
+++ b/steam/trade.py
@@ -453,7 +453,9 @@ class TradeOffer:
         trade.partner = int(data["accountid_other"])  # type: ignore
         return trade
 
-    def _update_from_send(self, state: ConnectionState, data: dict[str, Any], partner: User, active: bool = True) -> None:
+    def _update_from_send(
+        self, state: ConnectionState, data: dict[str, Any], partner: User, active: bool = True
+    ) -> None:
         self.id = int(data["tradeofferid"])
         self._state = state
         self.partner = partner

--- a/steam/trade.py
+++ b/steam/trade.py
@@ -453,11 +453,11 @@ class TradeOffer:
         trade.partner = int(data["accountid_other"])  # type: ignore
         return trade
 
-    def _update_from_send(self, state: ConnectionState, data: dict[str, Any], partner: User) -> None:
+    def _update_from_send(self, state: ConnectionState, data: dict[str, Any], partner: User, active: bool = True) -> None:
         self.id = int(data["tradeofferid"])
         self._state = state
         self.partner = partner
-        self.state = TradeOfferState.Active
+        self.state = TradeOfferState.Active if active else TradeOfferState.ConfirmationNeed
         self.created_at = datetime.utcnow()
 
     def __repr__(self) -> str:

--- a/steam/user.py
+++ b/steam/user.py
@@ -180,6 +180,7 @@ class User(BaseUser, Messageable["UserMessage"]):
             to_receive = [item.to_dict() for item in trade.items_to_receive]
             resp = await self._state.http.send_trade_offer(self, to_send, to_receive, trade.token, trade.message or "")
             trade._has_been_sent = True
+            trade._update_from_send(self._state, resp, self)
             if resp.get("needs_mobile_confirmation", False):
                 for tries in range(5):
                     try:
@@ -188,7 +189,7 @@ class User(BaseUser, Messageable["UserMessage"]):
                         break
                     except ClientException:
                         await asyncio.sleep(tries * 2)
-            trade._update_from_send(self._state, resp, self)
+                trade._update_from_send(self._state, resp, self)
 
         return message
 

--- a/steam/user.py
+++ b/steam/user.py
@@ -180,7 +180,7 @@ class User(BaseUser, Messageable["UserMessage"]):
             to_receive = [item.to_dict() for item in trade.items_to_receive]
             resp = await self._state.http.send_trade_offer(self, to_send, to_receive, trade.token, trade.message or "")
             trade._has_been_sent = True
-            trade._update_from_send(self._state, resp, self)
+            trade._update_from_send(self._state, resp, self, active=not resp.get("needs_mobile_confirmation", False))
             if resp.get("needs_mobile_confirmation", False):
                 for tries in range(5):
                     try:


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
Before, client would not confirm tradeoffer because ClientException is raised when performing `trade.confirm()` -> `_check_active()` since tradeoffer state is Invalid.

Fix, update tradeoffer's state before attempting to confirm it.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
