### PR TITLE
Item owner descriptions

### DIFF
--- a/steam/trade.py
+++ b/steam/trade.py
@@ -257,7 +257,7 @@ class Item(Asset):
         self.name = data.get("market_name")
         self.display_name = data.get("name")
         self.colour = int(data["name_color"], 16) if "name_color" in data else None
-        self.descriptions = data.get("descriptions")
+        self.descriptions = [*data.get("descriptions"), *data.get("owner_descriptions", [])]
         self.type = data.get("type")
         self.tags = data.get("tags")
         self.icon_url = (

--- a/steam/trade.py
+++ b/steam/trade.py
@@ -82,7 +82,8 @@ class DescriptionDict(TypedDict, total=False):
     name_color: str
     background_color: str  # hex code
     type: str
-    descriptions: dict[str, str]
+    descriptions: list[dict[str, str]]
+    owner_descriptions: list[dict[str, str]]
     market_actions: list[dict[str, str]]
     actions: list[dict[str, str]]
     tags: list[dict[str, str]]
@@ -221,7 +222,9 @@ class Item(Asset):
     colour
         The colour of the item.
     descriptions
-        The descriptions of the item. Also extended with owner descriptions if they exist.
+        The descriptions of the item.
+    owner_descriptions
+        The descriptions of the item which are visible only to the owner of the item.
     type
         The type of the item.
     tags
@@ -242,6 +245,7 @@ class Item(Asset):
         "icon_url",
         "display_name",
         "descriptions",
+        "owner_descriptions",
         "fraud_warnings",
         "actions",
         "_is_tradable",
@@ -257,7 +261,8 @@ class Item(Asset):
         self.name = data.get("market_name")
         self.display_name = data.get("name")
         self.colour = int(data["name_color"], 16) if "name_color" in data else None
-        self.descriptions = [*data.get("descriptions"), *data.get("owner_descriptions", [])]
+        self.descriptions = data.get("descriptions")
+        self.owner_descriptions = data.get("owner_descriptions", [])
         self.type = data.get("type")
         self.tags = data.get("tags")
         self.icon_url = (

--- a/steam/trade.py
+++ b/steam/trade.py
@@ -221,7 +221,7 @@ class Item(Asset):
     colour
         The colour of the item.
     descriptions
-        The descriptions of the item.
+        The descriptions of the item. Also extended with owner descriptions if they exist.
     type
         The type of the item.
     tags


### PR DESCRIPTION
## Summary

The problem is getting the `owner_descriptions` from the item of inventory, which may contain important information like "Tradable After". This is an addition to the descriptions, which only the owner of the item can see, so I decided to extend `descriptions` with them. But perhaps such a change is more breaking in some cases than adding another attribute for them.

## Checklist

- [x] If code changes were made then they have been tested.
- [x] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
