### PR TITLE
JSON_DUMPS throws NameError it should json.dumps

### DIFF
--- a/steam/http.py
+++ b/steam/http.py
@@ -522,7 +522,7 @@ class HTTPClient:
             "serverid": 1,
             "partner": user.id64,
             "tradeoffermessage": offer_message,
-            "json_tradeoffer": JSON_DUMPS(
+            "json_tradeoffer": json.dumps(
                 {
                     "newversion": True,
                     "version": len(to_send) + len(to_receive) + 1,
@@ -531,7 +531,7 @@ class HTTPClient:
                 }
             ),
             "captcha": "",
-            "trade_offer_create_params": JSON_DUMPS({"trade_offer_access_token": token}) if token is not None else "{}",
+            "trade_offer_create_params": json.dumps({"trade_offer_access_token": token}) if token is not None else "{}",
             **kwargs,
         }
         referer = URL.COMMUNITY / f"tradeoffer/new/?partner={user.id}"


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This pull request fixes the "NameError: name 'JSON_DUMPS' is not defined" issue, which originates from http.py by replacing "JSON_DUMPS" with "json.dumps".
## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
