### PR TITLE
Get smaller icon url instead of None in Item

### DIFF
--- a/steam/trade.py
+++ b/steam/trade.py
@@ -194,7 +194,7 @@ class Item(Asset):
         self.icon_url = (
             f'https://steamcommunity-a.akamaihd.net/economy/image/{data["icon_url_large"]}'
             if "icon_url_large" in data
-            else None
+            else f'https://steamcommunity-a.akamaihd.net/economy/image/{data["icon_url"]}'
         )
         self.fraud_warnings = data.get("fraudwarnings", [])
         self.actions = data.get("actions", [])

--- a/steam/trade.py
+++ b/steam/trade.py
@@ -194,7 +194,7 @@ class Item(Asset):
         self.icon_url = (
             f'https://steamcommunity-a.akamaihd.net/economy/image/{data["icon_url_large"]}'
             if "icon_url_large" in data
-            else f'https://steamcommunity-a.akamaihd.net/economy/image/{data["icon_url"]}'
+            else f"https://steamcommunity-a.akamaihd.net/economy/image/{data['icon_url']}"
         )
         self.fraud_warnings = data.get("fraudwarnings", [])
         self.actions = data.get("actions", [])


### PR DESCRIPTION
## Summary

Changed Item class to get any icon_url instead of None if "icon_url_large" is missing

## Checklist

- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
