### PR TITLE
Fix to 'Make steam.utils.parse_trade_url return a rich object' 

### DIFF
--- a/steam/utils.py
+++ b/steam/utils.py
@@ -100,9 +100,12 @@ def verify_signature(data: bytes, signature: bytes) -> bool:
         return True
 
 
-class TradeURLInfo(NamedTuple):
+@dataclass
+class TradeURLInfo:
     token: str
     id: ID
+    def __post_init__(self):
+        self.url = f"https://steamcommunity.com/tradeoffer/new/?partner={self.id}&token={self.token}"
 
 
 def parse_trade_url(url: StrOrURL) -> TradeURLInfo | None:
@@ -115,7 +118,9 @@ def parse_trade_url(url: StrOrURL) -> TradeURLInfo | None:
 
     Returns
     -------
-    A :class:`re.Match` object with ``token`` and ``user_id`` :meth:`re.Match.group`|`TradeURLInfo` objects or ``None``.
+    TradeURLInfo is a :class:`typing.NamedTuple` defined as:
+            
+    .. source:: TradeURLInfo
     """
     if (
         match := re.match(
@@ -125,8 +130,8 @@ def parse_trade_url(url: StrOrURL) -> TradeURLInfo | None:
         )
     ) is None:
         return None
-    else:
-        return TradeURLInfo(match["token"], ID(match["user_id"]))
+        
+    return TradeURLInfo(match["token"], ID(match["user_id"]))
 
 
 _SelfT = TypeVar("_SelfT")

--- a/steam/utils.py
+++ b/steam/utils.py
@@ -120,7 +120,7 @@ def parse_trade_url(url: StrOrURL) -> TradeURLInfo | None:
 
     Returns
     -------
-    TradeURLInfo is a :class:`typing.NamedTuple` defined as:
+    TradeURLInfo is a :func:`~dataclasses.dataclass` defined as:
 
     .. source:: TradeURLInfo
     """

--- a/steam/utils.py
+++ b/steam/utils.py
@@ -7,6 +7,7 @@ The appropriate licenses are in LICENSE
 """
 
 from __future__ import annotations
+from ._const import URL
 
 import abc
 import asyncio
@@ -26,6 +27,7 @@ from collections.abc import (
     Mapping,
     Sized,
 )
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from inspect import getmembers, isawaitable
 from io import BytesIO

--- a/steam/utils.py
+++ b/steam/utils.py
@@ -104,6 +104,7 @@ def verify_signature(data: bytes, signature: bytes) -> bool:
 class TradeURLInfo:
     token: str
     id: ID
+
     def __post_init__(self):
         self.url = f"https://steamcommunity.com/tradeoffer/new/?partner={self.id}&token={self.token}"
 
@@ -119,7 +120,7 @@ def parse_trade_url(url: StrOrURL) -> TradeURLInfo | None:
     Returns
     -------
     TradeURLInfo is a :class:`typing.NamedTuple` defined as:
-            
+
     .. source:: TradeURLInfo
     """
     if (
@@ -130,7 +131,7 @@ def parse_trade_url(url: StrOrURL) -> TradeURLInfo | None:
         )
     ) is None:
         return None
-        
+
     return TradeURLInfo(match["token"], ID(match["user_id"]))
 
 

--- a/steam/utils.py
+++ b/steam/utils.py
@@ -105,8 +105,9 @@ class TradeURLInfo:
     token: str
     id: ID
 
-    def __post_init__(self):
-        self.url = f"https://steamcommunity.com/tradeoffer/new/?partner={self.id}&token={self.token}"
+    @property
+    def url(self) -> str:
+        return URL.COMMUNITY / f"tradeoffer/new/?partner={self.id}&token={self.token}"
 
 
 def parse_trade_url(url: StrOrURL) -> TradeURLInfo | None:

--- a/steam/utils.py
+++ b/steam/utils.py
@@ -7,7 +7,6 @@ The appropriate licenses are in LICENSE
 """
 
 from __future__ import annotations
-from ._const import URL
 
 import abc
 import asyncio
@@ -42,7 +41,7 @@ from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 from typing_extensions import Self
 
-from ._const import MISSING
+from ._const import MISSING, URL
 from .enums import _is_descriptor, classproperty as classproperty
 from .id import (
     ID,

--- a/steam/utils.py
+++ b/steam/utils.py
@@ -43,12 +43,12 @@ from typing_extensions import Self
 from ._const import MISSING
 from .enums import _is_descriptor, classproperty as classproperty
 from .id import (
+    ID,
     id64_from_url as id64_from_url,
     parse_id2 as parse_id2,
     parse_id3 as parse_id3,
     parse_id64 as parse_id64,
     parse_invite_code as parse_invite_code,
-    ID,
 )
 
 if TYPE_CHECKING:


### PR DESCRIPTION
…Tuple'

## Summary

A Fix to 'Make steam.utils.parse_trade_url return a proper Tuple

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [x] I have updated the documentation to reflect the changes. (Needs to be checked)
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
