### PR TITLE
change op request param "accept" to "allow" to fix mobileconfs

### DIFF
--- a/steam/guard.py
+++ b/steam/guard.py
@@ -95,6 +95,8 @@ def get_device_id(id64: int) -> str:
 
 
 Tags: TypeAlias = Literal["conf", "details", "accept", "reject", "list"]
+#Tags: TypeAlias = Literal["conf", "details", "allow", "cancel", "list"]
+# TODO: I'm not sure if these should also be modified to their old value (in the commented out line)
 
 
 @dataclass(repr=False, slots=True)
@@ -127,10 +129,12 @@ class Confirmation:
         if not resp["success"]:
             raise ConfirmationError(resp.get("message", "Unknown error"))
 
+# TODO: determine why keywords are right? test `cancel` 
     async def confirm(self) -> None:
         await self._perform_op("allow")
-        # ^ this is no longer "accept" as of the endpoint update to /mobileconf/getlist/ -- it is "allow" now
+        # ^ this is no longer "accept" as of the endpoint update to /mobileconf/getlist/ -- it is "allow", as it... used to be...
         # "yeah idk either" -- @zudsniper
 
     async def cancel(self) -> None:
-        await self._perform_op("reject")
+        await self._perform_op("cancel")
+        # ^ this is a change to conform with the revert of mobile API key words -- so `reject` -> `cancel`

--- a/steam/guard.py
+++ b/steam/guard.py
@@ -95,7 +95,7 @@ def get_device_id(id64: int) -> str:
 
 
 Tags: TypeAlias = Literal["conf", "details", "accept", "reject", "list"]
-#Tags: TypeAlias = Literal["conf", "details", "allow", "cancel", "list"]
+# Tags: TypeAlias = Literal["conf", "details", "allow", "cancel", "list"]
 # TODO: I'm not sure if these should also be modified to their old value (in the commented out line)
 
 
@@ -129,7 +129,7 @@ class Confirmation:
         if not resp["success"]:
             raise ConfirmationError(resp.get("message", "Unknown error"))
 
-# TODO: determine why keywords are right? test `cancel` 
+    # TODO: determine why keywords are right? test `cancel`
     async def confirm(self) -> None:
         await self._perform_op("allow")
         # ^ this is no longer "accept" as of the endpoint update to /mobileconf/getlist/ -- it is "allow", as it... used to be...

--- a/steam/guard.py
+++ b/steam/guard.py
@@ -128,7 +128,9 @@ class Confirmation:
             raise ConfirmationError(resp.get("message", "Unknown error"))
 
     async def confirm(self) -> None:
-        await self._perform_op("accept")
+        await self._perform_op("allow")
+        # ^ this is no longer "accept" as of the endpoint update to /mobileconf/getlist/ -- it is "allow" now
+        # "yeah idk either" -- @zudsniper
 
     async def cancel(self) -> None:
         await self._perform_op("reject")


### PR DESCRIPTION
## Summary
This is a minuscule change in response to issue #260 which **_seems_** to have resolved the problem. The fix was extremely simple: the request parameter within the mobile confirmation system simply has a field labelled `op` which needed to be set to `'allow'` instead of `'accept'`. 

### Tested Environments 
- `Windows 10`
- `MacOS Catalina 10.15`
- `Debian 11.6 Bullseye`

<!-- What is this pull request for? Does it fix any issues? -->

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.  
  > _correct me if I'm wrong but I couldn't find any documentation to update regarding this change._  
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
