### PR TITLE
Fixed wrong metal addition result

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ venv
 .mypy_cache
 .pytest_cache
 .ruff_cache
+.hypothesis
 
 .DS_Store
 Thumbs.db

--- a/poetry.lock
+++ b/poetry.lock
@@ -823,6 +823,38 @@ files = [
 ]
 
 [[package]]
+name = "hypothesis"
+version = "6.82.0"
+description = "A library for property-based testing"
+optional = false
+python-versions = ">=3.8"
+files = [
+    {file = "hypothesis-6.82.0-py3-none-any.whl", hash = "sha256:fa8eee429b99f7d3c953fb2b57de415fd39b472b09328b86c1978f12669ef395"},
+    {file = "hypothesis-6.82.0.tar.gz", hash = "sha256:ffece8e40a34329e7112f7408f2c45fe587761978fdbc6f4f91bf0d683a7d4d9"},
+]
+
+[package.dependencies]
+attrs = ">=19.2.0"
+exceptiongroup = {version = ">=1.0.0", markers = "python_version < \"3.11\""}
+sortedcontainers = ">=2.1.0,<3.0.0"
+
+[package.extras]
+all = ["backports.zoneinfo (>=0.2.1)", "black (>=19.10b0)", "click (>=7.0)", "django (>=3.2)", "dpcontracts (>=0.4)", "lark (>=0.10.1)", "libcst (>=0.3.16)", "numpy (>=1.17.3)", "pandas (>=1.1)", "pytest (>=4.6)", "python-dateutil (>=1.4)", "pytz (>=2014.1)", "redis (>=3.0.0)", "rich (>=9.0.0)", "tzdata (>=2023.3)"]
+cli = ["black (>=19.10b0)", "click (>=7.0)", "rich (>=9.0.0)"]
+codemods = ["libcst (>=0.3.16)"]
+dateutil = ["python-dateutil (>=1.4)"]
+django = ["django (>=3.2)"]
+dpcontracts = ["dpcontracts (>=0.4)"]
+ghostwriter = ["black (>=19.10b0)"]
+lark = ["lark (>=0.10.1)"]
+numpy = ["numpy (>=1.17.3)"]
+pandas = ["pandas (>=1.1)"]
+pytest = ["pytest (>=4.6)"]
+pytz = ["pytz (>=2014.1)"]
+redis = ["redis (>=3.0.0)"]
+zoneinfo = ["backports.zoneinfo (>=0.2.1)", "tzdata (>=2023.3)"]
+
+[[package]]
 name = "identify"
 version = "2.5.24"
 description = "File identification library for Python"
@@ -1770,6 +1802,17 @@ files = [
 ]
 
 [[package]]
+name = "sortedcontainers"
+version = "2.4.0"
+description = "Sorted Containers -- Sorted List, Sorted Dict, Sorted Set"
+optional = false
+python-versions = "*"
+files = [
+    {file = "sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0"},
+    {file = "sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88"},
+]
+
+[[package]]
 name = "soupsieve"
 version = "2.4.1"
 description = "A modern CSS selector implementation for Beautiful Soup."
@@ -2131,4 +2174,4 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.10"
-content-hash = "e34ca3532cfe57115312c6bc3fba4cadfcfb812c86cbfa8b1e5d3fe8d3371984"
+content-hash = "a82bc2efc6a474c3742f47cd10acde2d038985f2a73beb1f4a3833354e471375"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -76,6 +76,7 @@ poethepoet = ">=0.19,<0.22"
 blacken-docs = "^1.12"
 ruff = ">=0.0.261,<0.0.279"
 tomli = {version = "~2", python = "<3.11"}
+hypothesis = "^6.82.0"
 
 [tool.poe.tasks]
 test = {cmd = "pytest tests", help = "Run the tests"}

--- a/steam/ext/tf2/currency.py
+++ b/steam/ext/tf2/currency.py
@@ -64,10 +64,10 @@ class Metal(Fraction):
         scrap = cls.extract_scrap(value)
 
         if scrap < 0:
-            raise ValueError(f'Metal value cannot be negative')
+            raise ValueError(f"Metal value cannot be negative")
 
         return super().__new__(cls, scrap, 9)
-    
+
     @classmethod
     def extract_scrap(cls, value: SupportsMetal) -> int:
         if isinstance(value, Fraction):
@@ -87,27 +87,27 @@ class Metal(Fraction):
         digits = round(fractional, 2).as_tuple().digits
         if len(digits) >= 2 and digits[0] != digits[1]:
             raise ValueError("metal value must be a multiple of 0.11")
-        
+
         return int(integer) * 9 + digits[0]
-    
+
     def __add__(self, other: SupportsMetal) -> Fraction:
         scrap = Metal.extract_scrap(other)
         return Metal(Fraction(self.numerator + scrap, 9))
-    
+
     def __sub__(self, other: SupportsMetal) -> Fraction:
         scrap = Metal.extract_scrap(other)
         return Metal(Fraction(self.numerator - scrap, 9))
-    
+
     def __mul__(self, other: SupportsMetal) -> Fraction:
         scrap = Metal.extract_scrap(other)
         return Metal(Fraction(self.numerator * scrap, 9))
-    
+
     def __div__(self, other: SupportsMetal) -> Fraction:
         scrap = Metal.extract_scrap(other)
 
         if self.numerator % scrap != 0:
-            raise ValueError(f'{self.numerator} scrap cannot be divided by {scrap}')
-        
+            raise ValueError(f"{self.numerator} scrap cannot be divided by {scrap}")
+
         return Metal(Fraction(self.numerator // scrap, 9))
 
     def __str__(self) -> str:

--- a/steam/ext/tf2/currency.py
+++ b/steam/ext/tf2/currency.py
@@ -3,26 +3,38 @@
 from __future__ import annotations
 
 import math
+from decimal import Decimal
 from fractions import Fraction
-from typing import Final, SupportsFloat, SupportsIndex, SupportsRound, TypeAlias, overload
+from typing import TypeAlias, overload
 
 from typing_extensions import Self
 
 __all__ = ("Metal",)
 
 
-class SupportsRoundOrFloat(SupportsRound[int], SupportsFloat):
-    ...
+SupportsMetal: TypeAlias = int | str | float | Fraction | Decimal
 
 
-class SupportsRoundOrIndex(SupportsRound[int], SupportsIndex):
-    ...
+def modf(value: Decimal) -> tuple[Decimal, Decimal]:
+    # can't just use divmod(value, 1) as both raise for large Decimals because lol,
+    # so we need this whole song and dance
+    as_tuple = value.as_tuple()
+    if not isinstance(as_tuple.exponent, int):
+        raise ValueError(f"invalid exponent {as_tuple.exponent!r}")
+
+    if not as_tuple.exponent:
+        integer = value
+        fractional = Decimal()
+    elif as_tuple.exponent < 0:
+        integer = Decimal((as_tuple.sign, as_tuple.digits[: as_tuple.exponent], 0))
+        fractional = Decimal((as_tuple.sign, as_tuple.digits[as_tuple.exponent :], as_tuple.exponent))
+    else:
+        raise AssertionError("shouldn't be reachable")
+
+    return fractional, integer
 
 
-SupportsMetal: TypeAlias = float | str | SupportsRoundOrFloat | SupportsRoundOrIndex
-
-
-# TODO look into the discuss post about returning Self() in subclasses instead of concrete instances
+# TODO use https://github.com/python/cpython/pull/106223 when it's merged
 class Metal(Fraction):
     """A class to represent some metal in TF2.
 
@@ -36,6 +48,10 @@ class Metal(Fraction):
         Metal("1.22") == Metal(1.22)
         Metal(1.22) == Metal(1.22)
         Metal(1) == Metal(1.00)
+
+    Note
+    ----
+    When working with large floating point numbers, it's recommended to pass a :class:`str` to avoid precision loss.
     """
 
     __slots__ = ()
@@ -45,32 +61,57 @@ class Metal(Fraction):
         ...
 
     def __new__(cls, value: SupportsMetal, /, *, _normalize: bool = ...) -> Self:
-        if isinstance(value, str):  # '1.22'
-            value = float(value)
+        scrap = cls.extract_scrap(value)
 
-        self = object.__new__(cls)
+        if scrap < 0:
+            raise ValueError(f'Metal value cannot be negative')
+
+        return super().__new__(cls, scrap, 9)
+    
+    @classmethod
+    def extract_scrap(cls, value: SupportsMetal) -> int:
+        if isinstance(value, Fraction):
+            if value.denominator in {9, 3, 1}:
+                return value.numerator * (9 // value.denominator)
+            raise ValueError("cannot convert Fraction to Metal, denominator isn't 1, 3 or 9")
 
         try:
-            true_value = round(value, 2)
+            value = Decimal(value)
         except (ValueError, TypeError):
             raise TypeError("non-int passed to Metal.__new__, that could not be cast") from None
 
-        if not math.isclose(value, true_value):
+        fractional, integer = modf(value)
+        if not math.isclose(fractional - round(fractional, 2), 0, abs_tol=1e-9):
             raise ValueError("metal value's last digits must be close to 0")
 
-        stred = f"{true_value:.2f}"
-        if stred[-1] != stred[-2]:
+        digits = round(fractional, 2).as_tuple().digits
+        if len(digits) >= 2 and digits[0] != digits[1]:
             raise ValueError("metal value must be a multiple of 0.11")
+        
+        return int(integer) * 9 + digits[0]
+    
+    def __add__(self, other: SupportsMetal) -> Fraction:
+        scrap = Metal.extract_scrap(other)
+        return Metal(Fraction(self.numerator + scrap, 9))
+    
+    def __sub__(self, other: SupportsMetal) -> Fraction:
+        scrap = Metal.extract_scrap(other)
+        return Metal(Fraction(self.numerator - scrap, 9))
+    
+    def __mul__(self, other: SupportsMetal) -> Fraction:
+        scrap = Metal.extract_scrap(other)
+        return Metal(Fraction(self.numerator * scrap, 9))
+    
+    def __div__(self, other: SupportsMetal) -> Fraction:
+        scrap = Metal.extract_scrap(other)
 
-        self._numerator = round(true_value * 9)
-        return self
-
-    denominator: Final = 9  # type: ignore
-    _numerator: int
-    _denominator: Final = 9
+        if self.numerator % scrap != 0:
+            raise ValueError(f'{self.numerator} scrap cannot be divided by {scrap}')
+        
+        return Metal(Fraction(self.numerator // scrap, 9))
 
     def __str__(self) -> str:
-        return f"{self._numerator / 9:.2f}"
+        return f"{self.numerator // self.denominator}.{f'{(self.numerator % self.denominator) * 9 // self.denominator}' * 2}"
 
     def __repr__(self) -> str:
-        return f"{self.__class__.__name__}({str(self)})"
+        return f"{self.__class__.__name__}({str(self)!r})"

--- a/tests/unit/test_ext_tf2.py
+++ b/tests/unit/test_ext_tf2.py
@@ -69,6 +69,7 @@ def test_metal_invalid_values():
     with pytest.raises(ValueError):
         tf2.Metal(Fraction(1, 10))
 
+
 def test_str():
     assert str(tf2.Metal(1.22)) == "1.22"
     assert str(tf2.Metal(1.33)) == "1.33"

--- a/tests/unit/test_ext_tf2.py
+++ b/tests/unit/test_ext_tf2.py
@@ -3,6 +3,7 @@ from decimal import Decimal
 from fractions import Fraction
 
 import pytest
+from hypothesis import given, strategies as st
 
 from steam.ext import tf2
 
@@ -14,7 +15,14 @@ def test_metal_initializations():
     assert tf2.Metal(Fraction(7, 9)) == tf2.Metal(0.77)
     assert tf2.Metal(Decimal(0.77)) == tf2.Metal(0.77)
     assert tf2.Metal(Fraction(18, 9)) == tf2.Metal(2)
-    assert tf2.Metal(1.00) == tf2.Metal(1)
+    assert tf2.Metal(1.11) + tf2.Metal(1) == tf2.Metal(2.11)
+    assert tf2.Metal(1.88) + tf2.Metal(1.11) == tf2.Metal(3)
+    assert tf2.Metal(1.11) + tf2.Metal(1.11) == tf2.Metal(2.22)
+    assert tf2.Metal(1.88) + tf2.Metal(1.88) == tf2.Metal(3.77)
+    assert tf2.Metal(1.00) + tf2.Metal(0) == tf2.Metal(1)
+
+    assert tf2.Metal(1.99) == tf2.Metal(2)
+    # TODO test inf prec
 
 
 def test_metal_addition():
@@ -60,3 +68,19 @@ def test_metal_invalid_values():
         tf2.Metal(1.115)
     with pytest.raises(ValueError):
         tf2.Metal(Fraction(1, 10))
+
+def test_str():
+    assert str(tf2.Metal(1.22)) == "1.22"
+    assert str(tf2.Metal(1.33)) == "1.33"
+    assert str(tf2.Metal(1000)) == "1000.00"
+
+
+# some property tests
+@given(st.integers(), st.integers())
+def test_ints_are_commutative(x: int, y: int):
+    assert x + y == y + x
+
+
+@given(x=st.integers(), y=st.integers())
+def test_ints_cancel(x: int, y: int):
+    assert (tf2.Metal(x) + tf2.Metal(y)) - tf2.Metal(y) == tf2.Metal(x)

--- a/tests/unit/test_ext_tf2.py
+++ b/tests/unit/test_ext_tf2.py
@@ -1,3 +1,4 @@
+# pyright: reportUnusedExpression = false
 from decimal import Decimal
 from fractions import Fraction
 
@@ -27,16 +28,29 @@ def test_metal_subtraction():
     assert tf2.Metal(1.11) - tf2.Metal(1) == tf2.Metal(0.11)
     assert tf2.Metal(1.11) - tf2.Metal(0) == tf2.Metal(1.11)
 
-    with pytest.raises(ValueError):
-        _ = tf2.Metal(1) - tf2.Metal(1.11)
+    assert tf2.Metal(1) - tf2.Metal(1.11) == tf2.Metal(-0.11)
 
 
 def test_metal_multiplication():
     assert tf2.Metal(3) * 3 == tf2.Metal(9)
     assert tf2.Metal(0) * 3 == tf2.Metal(0)
 
+    assert tf2.Metal(3) * -1 == tf2.Metal(-3)
+
+
+def test_metal_division():
+    assert tf2.Metal(2) / 2 == tf2.Metal(1)
+    assert tf2.Metal(2) / -2 == tf2.Metal(-1)
+
     with pytest.raises(ValueError):
-        _ = tf2.Metal(3) * -1
+        tf2.Metal(5) / 2
+    with pytest.raises(ValueError):
+        tf2.Metal(5) / -2
+    with pytest.raises(ValueError):
+        -tf2.Metal(5) / 2
+
+    with pytest.raises(ZeroDivisionError):
+        tf2.Metal(2) / 0
 
 
 def test_metal_invalid_values():
@@ -44,3 +58,5 @@ def test_metal_invalid_values():
         tf2.Metal(1.12)
     with pytest.raises(ValueError):
         tf2.Metal(1.115)
+    with pytest.raises(ValueError):
+        tf2.Metal(Fraction(1, 10))

--- a/tests/unit/test_ext_tf2.py
+++ b/tests/unit/test_ext_tf2.py
@@ -1,3 +1,6 @@
+from decimal import Decimal
+from fractions import Fraction
+
 import pytest
 
 from steam.ext import tf2
@@ -5,8 +8,35 @@ from steam.ext import tf2
 client = tf2.Client()
 
 
+def test_metal_initializations():
+    assert tf2.Metal("0.77") == tf2.Metal(0.77)
+    assert tf2.Metal(Fraction(7, 9)) == tf2.Metal(0.77)
+    assert tf2.Metal(Decimal(0.77)) == tf2.Metal(0.77)
+    assert tf2.Metal(Fraction(18, 9)) == tf2.Metal(2)
+    assert tf2.Metal(1.00) == tf2.Metal(1)
+
+
 def test_metal_addition():
     assert tf2.Metal(1.11) + tf2.Metal(1) == tf2.Metal(2.11)
+    assert tf2.Metal(1.88) + tf2.Metal(1.11) == tf2.Metal(3)
+    assert tf2.Metal(1.11) + tf2.Metal(1.11) == tf2.Metal(2.22)
+    assert tf2.Metal(1.88) + tf2.Metal(1.88) == tf2.Metal(3.77)
+
+
+def test_metal_subtraction():
+    assert tf2.Metal(1.11) - tf2.Metal(1) == tf2.Metal(0.11)
+    assert tf2.Metal(1.11) - tf2.Metal(0) == tf2.Metal(1.11)
+
+    with pytest.raises(ValueError):
+        _ = tf2.Metal(1) - tf2.Metal(1.11)
+
+
+def test_metal_multiplication():
+    assert tf2.Metal(3) * 3 == tf2.Metal(9)
+    assert tf2.Metal(0) * 3 == tf2.Metal(0)
+
+    with pytest.raises(ValueError):
+        _ = tf2.Metal(3) * -1
 
 
 def test_metal_invalid_values():

--- a/tests/unit/test_ext_tf2.py
+++ b/tests/unit/test_ext_tf2.py
@@ -15,14 +15,7 @@ def test_metal_initializations():
     assert tf2.Metal(Fraction(7, 9)) == tf2.Metal(0.77)
     assert tf2.Metal(Decimal(0.77)) == tf2.Metal(0.77)
     assert tf2.Metal(Fraction(18, 9)) == tf2.Metal(2)
-    assert tf2.Metal(1.11) + tf2.Metal(1) == tf2.Metal(2.11)
-    assert tf2.Metal(1.88) + tf2.Metal(1.11) == tf2.Metal(3)
-    assert tf2.Metal(1.11) + tf2.Metal(1.11) == tf2.Metal(2.22)
-    assert tf2.Metal(1.88) + tf2.Metal(1.88) == tf2.Metal(3.77)
-    assert tf2.Metal(1.00) + tf2.Metal(0) == tf2.Metal(1)
-
     assert tf2.Metal(1.99) == tf2.Metal(2)
-    # TODO test inf prec
 
 
 def test_metal_addition():
@@ -30,6 +23,8 @@ def test_metal_addition():
     assert tf2.Metal(1.88) + tf2.Metal(1.11) == tf2.Metal(3)
     assert tf2.Metal(1.11) + tf2.Metal(1.11) == tf2.Metal(2.22)
     assert tf2.Metal(1.88) + tf2.Metal(1.88) == tf2.Metal(3.77)
+    assert tf2.Metal(1.00) + tf2.Metal(0) == tf2.Metal(1)
+    # TODO test inf prec
 
 
 def test_metal_subtraction():


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

This PR fixes a case when `tf2.Metal(1.88) + tf2.Metal(1.11) != tf2.Metal(3)` and adds some more test cases to assure it. It also enforces `Metal.__add__` method to return an instance of a `Metal` instead of a `Fracture` to make addition chains of more than 2 elements stable (due to rounding and returning an instance of `Fracture`, the required precision could be lost after multiple additions). The breaking change here though is adding anything other than `Fracture` with denominator 9 to `Metal` will result in an error.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [x] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
