### PR TITLE
Added supported_language tweaks on AppInfo

### DIFF
--- a/steam/manifest.py
+++ b/steam/manifest.py
@@ -950,7 +950,7 @@ class AppInfo(ProductInfo, PartialApp[str]):
         self.language_support = {
             Language.from_str(language): support
             for language, support in (common.get("supported_languages") or MultiDict()).items()
-            if not isinstance(common.get("supported_languages"), str)
+            if isinstance(common.get("supported_languages"), MultiDict)
         }
         """This app's language support."""
 

--- a/steam/manifest.py
+++ b/steam/manifest.py
@@ -949,7 +949,8 @@ class AppInfo(ProductInfo, PartialApp[str]):
 
         self.language_support = {
             Language.from_str(language): support
-            for language, support in common.get("supported_languages", MultiDict()).items()
+            for language, support in (common.get("supported_languages") or MultiDict()).items()
+            if isinstance(common.get("supported_languages"), dict)
         }
         """This app's language support."""
 

--- a/steam/manifest.py
+++ b/steam/manifest.py
@@ -950,7 +950,7 @@ class AppInfo(ProductInfo, PartialApp[str]):
         self.language_support = {
             Language.from_str(language): support
             for language, support in (common.get("supported_languages") or MultiDict()).items()
-            if isinstance(common.get("supported_languages"), dict)
+            if not isinstance(common.get("supported_languages"), str)
         }
         """This app's language support."""
 

--- a/steam/types/manifest.py
+++ b/steam/types/manifest.py
@@ -40,7 +40,7 @@ class Common(TypedVDFDict, total=False):
     associations: VDFList[CommonAssociations]
     category: MultiDict[VDFBool]  # category_{id}: "1" cause lol valve
     languages: MultiDict[VDFBool]
-    supported_languages: MultiDict[LanguageSupport] | str # This can occasionally be an empty string
+    supported_languages: MultiDict[LanguageSupport] | str  # This can occasionally be an empty string
     steam_release_date: str
     review_score: str
     review_percentage: str

--- a/steam/types/manifest.py
+++ b/steam/types/manifest.py
@@ -40,7 +40,7 @@ class Common(TypedVDFDict, total=False):
     associations: VDFList[CommonAssociations]
     category: MultiDict[VDFBool]  # category_{id}: "1" cause lol valve
     languages: MultiDict[VDFBool]
-    supported_languages: MultiDict[LanguageSupport]
+    supported_languages: MultiDict[LanguageSupport] | str # This can occasionally be an empty string
     steam_release_date: str
     review_score: str
     review_percentage: str


### PR DESCRIPTION
## Summary

common.get("supported_languages")  occasionally returns an empty string -_- (e.g. for app 1332685), which causes existing code to explode since it expects a dictionary. This code is to handle that edge case.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
