### PR TITLE
Fix for protobufs bug

### DIFF
--- a/steam/ext/csgo/protobufs/cstrike.py
+++ b/steam/ext/csgo/protobufs/cstrike.py
@@ -3,7 +3,7 @@
 # plugin: python-betterproto
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 import betterproto
 
@@ -814,8 +814,8 @@ class PreviewDataBlock(betterproto.Message):
     quality: int = betterproto.uint32_field(6)
     paintwear: int = betterproto.uint32_field(7)
     paintseed: int = betterproto.uint32_field(8)
-    killeaterscoretype: int | None = betterproto.uint32_field(9, optional=True, group="_killeaterscoretype")
-    killeatervalue: int | None = betterproto.uint32_field(10, optional=True, group="_killeatervalue")
+    killeaterscoretype: Union[int, None] = betterproto.uint32_field(9, optional=True, group="_killeaterscoretype")
+    killeatervalue: Union[int, None] = betterproto.uint32_field(10, optional=True, group="_killeatervalue")
     customname: str = betterproto.string_field(11)
     stickers: "list[PreviewDataBlockSticker]" = betterproto.message_field(12)
     inventory: int = betterproto.uint32_field(13)


### PR DESCRIPTION
## Summary
It fixes the problem with parsing cstrike.Client2GcEconPreviewDataBlockResponse message

## Checklist

- [x] If code changes were made then they have been tested.
- [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
