### PR TITLE
Add csgo RankType and correct enumeration

### DIFF
--- a/steam/ext/csgo/enums.py
+++ b/steam/ext/csgo/enums.py
@@ -153,7 +153,7 @@ class Rank(IntEnum):
     @property
     def display_name(self) -> str:
         return self.DISPLAY_NAMES[self]
-    
+
 class RankType(IntEnum):
     Matchmaking          = 6
     Wingman              = 7

--- a/steam/ext/csgo/enums.py
+++ b/steam/ext/csgo/enums.py
@@ -153,7 +153,12 @@ class Rank(IntEnum):
     @property
     def display_name(self) -> str:
         return self.DISPLAY_NAMES[self]
-
+    
+class RankType(IntEnum):
+    Matchmaking          = 6
+    Wingman              = 7
+    CS2                  = 10
+    Dangerzone           = 11
 
 class EMsg(IntEnum):
     # ESOMsg

--- a/steam/ext/csgo/models.py
+++ b/steam/ext/csgo/models.py
@@ -234,7 +234,7 @@ class Ranking:
     def __init__(self, proto: cstrike.PlayerRankingInfo) -> None:
         self.rank = Rank(proto.rank_id) if proto.rank_type_id != 10 else proto.rank_id
         self.id = proto.rank_type_id
-        self.rank_type = RankType(proto.rank_type_id)
+        self.rank_type = RankType.try_value(proto.rank_type_id)
         self.change = proto.rank_change
         self.wins = proto.wins
         self.tv_control = proto.tv_control

--- a/steam/ext/csgo/models.py
+++ b/steam/ext/csgo/models.py
@@ -17,7 +17,7 @@ from ...id import parse_id64
 from ...types.id import ID32
 from ...utils import DateTime
 from ..commands.converters import Converter, UserConverter
-from .enums import Rank
+from .enums import Rank, RankType
 from .protobufs import cstrike
 
 if TYPE_CHECKING:
@@ -229,11 +229,12 @@ class Level(int):
 
 
 class Ranking:
-    __slots__ = ("rank", "id", "change", "wins", "tv_control")
+    __slots__ = ("rank", "id", "rank_type", "change", "wins", "tv_control")
 
     def __init__(self, proto: cstrike.PlayerRankingInfo) -> None:
-        self.rank = Rank(proto.rank_type_id)
-        self.id = proto.rank_id
+        self.rank = Rank(proto.rank_id) if proto.rank_type_id != 10 else proto.rank_id
+        self.id = proto.rank_type_id
+        self.rank_type = RankType(proto.rank_type_id)
         self.change = proto.rank_change
         self.wins = proto.wins
         self.tv_control = proto.tv_control

--- a/steam/ext/csgo/models.py
+++ b/steam/ext/csgo/models.py
@@ -232,7 +232,7 @@ class Ranking:
     __slots__ = ("rank", "id", "rank_type", "change", "wins", "tv_control")
 
     def __init__(self, proto: cstrike.PlayerRankingInfo) -> None:
-        self.rank = Rank(proto.rank_id) if proto.rank_type_id != 10 else proto.rank_id
+        self.rank = Rank.try_value(proto.rank_id) if proto.rank_type_id != 10 else proto.rank_id
         self.id = proto.rank_type_id
         self.rank_type = RankType.try_value(proto.rank_type_id)
         self.change = proto.rank_change


### PR DESCRIPTION
## Summary

Fixing correct Ranking and adding RankType like CS2 (Premier), Matchmaking (CSGO - old), Dangerzone and Wingman.

<!-- What is this pull request for? Does it fix any issues? -->
See above

## Checklist

- [x ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [x ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
