### PR TITLE
Move file_type prefix to media.py

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,18 +3,18 @@ ci:
 
 repos:
   - repo: https://github.com/psf/black
-    rev: 24.3.0
+    rev: 24.8.0
     hooks:
       - id: black
 
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.16.0
+    rev: 1.18.0
     hooks:
       - id: blacken-docs
         args: [--line-length=120, --target-version=py310]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.5
+    rev: v0.6.1
     hooks:
       - id: ruff
         args: [--fix]

--- a/steam/http.py
+++ b/steam/http.py
@@ -1102,7 +1102,7 @@ class HTTPClient:
             "file_sha": media.hash(contents),
             "file_image_width": media.width,
             "file_image_height": media.height,
-            "file_type": f"{media.type}",
+            "file_type": media.type,
         }
         resp = await self.post(URL.COMMUNITY / "chat/beginfileupload", data=payload)
 

--- a/steam/http.py
+++ b/steam/http.py
@@ -1102,7 +1102,7 @@ class HTTPClient:
             "file_sha": media.hash(contents),
             "file_image_width": media.width,
             "file_image_height": media.height,
-            "file_type": f"image/{media.type}",
+            "file_type": f"{media.type}",
         }
         resp = await self.post(URL.COMMUNITY / "chat/beginfileupload", data=payload)
 

--- a/steam/media.py
+++ b/steam/media.py
@@ -76,8 +76,10 @@ class Media:
                 if check != 0x0D0A1A0A:
                     raise ValueError("Opened file's headers do not match a standard PNGs headers")
                 width, height = struct.unpack(">ii", headers[16:24])
+                type_prefix = "image"
             case "gif":
                 width, height = struct.unpack("<HH", headers[6:10])
+                type_prefix = "image"
             case "jpeg":
                 try:
                     self.fp.seek(self._tell)  # read 0xff next
@@ -93,17 +95,19 @@ class Media:
                     # we are at a SOFn block
                     self.fp.seek(1, 1)  # skip 'precision' byte.
                     height, width = struct.unpack(">HH", self.fp.read(4))
+                    type_prefix = "image"
                 except Exception as exc:
                     raise ValueError from exc
             case "webm" | "mp4" | "mpeg" | "ogv":
                 width, height = 0, 0
+                type_prefix="video"
             case _:
                 raise TypeError("Unsupported file format passed")
-        self.type = type
+        self.type = type_prefix + "/" + type
         self.spoiler = spoiler
         self.width = width
         self.height = height
-        self.name = f'{int(time())}_{getattr(self.fp, "name", f"media.{self.type}")}'
+        self.name = f'{int(time())}_{getattr(self.fp, "name", f"media.{type}")}'
 
     def __enter__(self) -> Self:
         return self

--- a/steam/media.py
+++ b/steam/media.py
@@ -100,7 +100,7 @@ class Media:
                     raise ValueError from exc
             case "webm" | "mp4" | "mpeg" | "ogv":
                 width, height = 0, 0
-                type_prefix="video"
+                type_prefix = "video"
             case _:
                 raise TypeError("Unsupported file format passed")
         self.type = type_prefix + "/" + type

--- a/steam/media.py
+++ b/steam/media.py
@@ -103,7 +103,7 @@ class Media:
                 type_prefix = "video"
             case _:
                 raise TypeError("Unsupported file format passed")
-        self.type = type_prefix + "/" + type
+        self.type = f"{type_prefix}/{type}"
         self.spoiler = spoiler
         self.width = width
         self.height = height


### PR DESCRIPTION
## Summary

We shouldn't make everything and image :) 

Moves the filetype prefix (i.e. `image/` or `video/`) to media.py. 
Updates http.py to not prepend `image/` on every file_type


## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [x] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
