### PR TITLE
Fix Rich Presence Nulling

### DIFF
--- a/steam/user.py
+++ b/steam/user.py
@@ -62,6 +62,7 @@ class _BaseUser(BaseUser):
 
     def __init__(self, state: ConnectionState, proto: UserProto):
         super().__init__(state, proto.friendid)
+        self.rich_presence = None  # ensure the attr exists
         self._update(proto)
 
     def _update(self, proto: UserProto, /) -> None:
@@ -80,9 +81,8 @@ class _BaseUser(BaseUser):
         """The last time the user logged into steam."""
         self.last_seen_online = DateTime.from_timestamp(proto.last_seen_online)
         """The last time the user could be seen online."""
-        self.rich_presence = (
-            {message.key: message.value for message in proto.rich_presence} if proto.is_set("rich_presence") else None
-        )
+        if proto.is_set("rich_presence"):
+            self.rich_presence = {message.key: message.value for message in proto.rich_presence}
         """The rich presence of the user."""
         self.app = (
             PartialApp(self._state, name=proto.game_name, id=proto.game_played_app_id)


### PR DESCRIPTION
## Summary

<!-- What is this pull request for? Does it fix any issues? -->

Just a small PR out of #help thread.

## TL;DR for posterity

This PR fixes a bug where `rich_presence` attribute for user classes would reset its value to `None` if the incoming proto doesn't have `rich_presence` field set which occasionally does happen.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [X] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [X] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
