### PR TITLE
Add error for no mobile guard authentication

### DIFF
--- a/steam/http.py
+++ b/steam/http.py
@@ -206,7 +206,8 @@ class HTTPClient:
             or "You must have a validated email address to create a Steam Web API key" in resp
         ):
             raise RuntimeError("You must have a premium Steam account or validated email address to use this method")
-
+        if "<h2>Something is wrong</h2>" in resp:
+            raise RuntimeError("Your account does not meet the requirements for a developer API key. Your account requires Steam Guard Mobile Authenticator. ")
         key_re = re.compile(r"<p>Key: ([0-9A-F]+)</p>")
         if match := key_re.findall(resp):
             self.api_key = match[0]


### PR DESCRIPTION
This commit adds a RuntimeError for when a client doesn't have the Steam Guard Mobile Authenticator

## Summary

<!-- What is this pull request for? Does it fix any issues? -->
This PR adds an RuntimeError for when a client doesn't have Mobile 2FA Guard enabled.
The new requirements for an API Key are a Steam Mobile Guard Authenticator.

## Checklist

<!-- Put an x inside [ ] to check it, like so: [x] -->

- [x] If code changes were made, then they have been tested.
- [x] This PR fixes an issue.