### PR TITLE
Update aiohttp version constraint in pyproject.toml

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -96,7 +96,6 @@ import asyncio
 import steam
 from steam.ext import commands
 
-
 bot = commands.Bot(command_prefix="!")
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,7 @@ generate-setup-file = false
 
 [tool.poetry.dependencies]
 python = "^3.11"
-aiohttp = "^3.8"
+aiohttp = ">=3.8,<3.14"
 beautifulsoup4 = "^4.10"
 cryptography = ">=41,<43"
 betterproto = "2.0.0b6"


### PR DESCRIPTION
Apparently there was a breaking change in aiohttp 3.14, because I'm getting:

```
Traceback (most recent call last):
  File "/home/nicoco/src/perso/xmpp/slidge/modules/sleamdge/.venv/bin/sleamdge", line 4, in <module>
    from sleamdge import main
  File "/home/nicoco/src/perso/xmpp/slidge/modules/sleamdge/sleamdge/__init__.py", line 10, in <module>
    from . import command, config, contact, gateway, group, session
  File "/home/nicoco/src/perso/xmpp/slidge/modules/sleamdge/sleamdge/contact.py", line 6, in <module>
    import steam
  File "/home/nicoco/src/perso/xmpp/slidge/modules/sleamdge/.venv/lib/python3.12/site-packages/steam/__init__.py", line 19, in <module>
    from .client import *
  File "/home/nicoco/src/perso/xmpp/slidge/modules/sleamdge/.venv/lib/python3.12/site-packages/steam/client.py", line 54, in <module>
    from .state import ConnectionState
  File "/home/nicoco/src/perso/xmpp/slidge/modules/sleamdge/.venv/lib/python3.12/site-packages/steam/state.py", line 39, in <module>
    from .manifest import AppInfo, ContentServer, Manifest, PackageInfo
  File "/home/nicoco/src/perso/xmpp/slidge/modules/sleamdge/.venv/lib/python3.12/site-packages/steam/manifest.py", line 22, in <module>
    from aiohttp.streams import AsyncStreamReaderMixin
ImportError: cannot import name 'AsyncStreamReaderMixin' from 'aiohttp.streams' (/home/nicoco/src/perso/xmpp/slidge/modules/sleamdge/.venv/lib/python3.12/site-packages/aiohttp/streams.py)
```

## Summary

As a workaround in [sleamdge](https://codeberg.org/slidge/sleamdge/pulls/9) I had to add a constraint on aiohttp.

## Checklist

It's not tested on your repo directly, but I thought opening this PR is better than opening an issue, then a PR, etc.

- [ ] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [ ] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)
