### PR TITLE
Chore/quiet inventory noise

### DIFF
--- a/steam/ext/csgo/state.py
+++ b/steam/ext/csgo/state.py
@@ -129,7 +129,7 @@ class GCState(GCState_[Backpack]):
                 casket_id_low = utils.get(gc_item.attribute, def_index=272)
                 casket_id_high = utils.get(gc_item.attribute, def_index=273)
                 if not (casket_id_low and casket_id_high):
-                    log.info("Received an item that isn't our inventory %r", gc_item)
+                    log.debug("Received an item that isn't our inventory %r", gc_item)
                     continue  # the item has been removed (gc sometimes sends you items that you have deleted)
                 update_gc_item = True
                 gc_item = cast("CasketItem", utils.update_class(gc_item, CasketItem()))
@@ -246,7 +246,7 @@ class GCState(GCState_[Backpack]):
         if item is None and not (
             utils.get(cso_item.attribute, def_index=272) and utils.get(cso_item.attribute, def_index=273)
         ):  # it's also not a casket item
-            return log.info("Received an item that isn't our inventory %r", cso_item)
+            return log.debug("Received an item that isn't our inventory %r", cso_item)
 
         if item is not None:
             self.add_item_to_backpack(item)
@@ -275,7 +275,7 @@ class GCState(GCState_[Backpack]):
 
         before = utils.get(self.backpack, id=cso_item.id)
         if before is None:
-            return log.info("Received an item that isn't our inventory %r", cso_item)
+            return log.debug("Received an item that isn't our inventory %r", cso_item)
         after = utils.get(await self.update_backpack(cso_item), id=cso_item.id)
         self.dispatch("item_update", before, after)
 
@@ -287,7 +287,7 @@ class GCState(GCState_[Backpack]):
         deleted_item = base.Item().parse(msg.object_data)
         item = utils.get(self.backpack, id=deleted_item.id)
         if item is None:
-            return log.info("Received an item that isn't our inventory %r", deleted_item)
+            return log.debug("Received an item that isn't our inventory %r", deleted_item)
         for attribute_name in deleted_item.__annotations__:
             setattr(item, attribute_name, getattr(deleted_item, attribute_name))
         self.backpack.items.remove(item)  # type: ignore

--- a/steam/protobufs/notifications.py
+++ b/steam/protobufs/notifications.py
@@ -38,6 +38,10 @@ class MarkNotificationsReadNotification(UnifiedMessage, um_name="SteamNotificati
     mark_all_read: bool = betterproto.bool_field(4)
 
 
+class MarkNotificationsReadResponse(UnifiedMessage, um_name="SteamNotification.MarkNotificationsRead"):
+    pass
+
+
 class SetPreferencesRequest(UnifiedMessage, um_name="SteamNotification.SetPreferences"):
     preferences: "list[SteamNotificationPreference]" = betterproto.message_field(1)
 


### PR DESCRIPTION
## Summary

Small cleanup, two annoying log lines that don't actually mean anything's wrong.

First one: `steam/ext/csgo/state.py` logs "Received an item that isn't our inventory" at `INFO`, but the cases that trigger it are already known and handled fine (GC re-sending items you already deleted, or casket items handled elsewhere). Theres basically identical logs a few lines down for the same kinda thing that use `debug` instead, so I just made these consistent with those.

Second one's a bit more interesting. `MarkNotificationsReadNotification` in `steam/protobufs/notifications.py` was only ever registered for the outgoing/request side. Steam does send back a real ack for it though, and since there was no response class registered, parsing that ack blew up with a `TypeError` (`self.__class__ = MISSING`), got swallowed, and logged as this cryptic "Received an unknown EMsg.ServiceMethodResponse ... (SteamNotification.MarkNotificationsRead#1)" thing every single time. Added an empty `MarkNotificationsReadResponse` class (same trick allready used for `SetPreferencesResponse`) so it has somewhere to land.

## Checklist

- [x] If code changes were made then they have been tested.
  - [ ] I have updated the documentation to reflect the changes.
- [x] This PR fixes an issue.
- [ ] This PR adds something new (e.g. new method or parameters).
- [ ] This PR is a breaking change (e.g. methods or parameters removed/renamed)
- [ ] This PR is **not** a code change (e.g. documentation, README, ...)

Tested both against a real logged-in client on `85cc6995`. Checked that `MarkNotificationsRead#1` now resolves to a proper (request, response) pair instead of `(cls, MISSING)`, and left the app running through real notification/inventory traffic — neither log line showed up again, nothing else changed behavior-wise.
